### PR TITLE
Add support for rate-limiting GA hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ croct.plug({
     plugins: {
         googleAnalytics: {
             category: 'Croct',
+            rateLimit: 1000,
             events: {
                 eventOccurred: true,
                 testGroupAssigned: false,
@@ -53,6 +54,14 @@ croct.plug({
     }
 });
 ```
+
+Notice that all Analytics libraries implement a [rate-limiting mechanism](https://developers.google.com/analytics/devguides/collection/protocol/v1/limits-quotas) 
+that ensures you don't send too many hits at once, meaning that some events can be lost. The "rateLimit" option 
+allows you to limit the maximum number of hits in a given interval. For example, passing 500ms causes the function 
+to be called at most one time per 500ms – or two times per second.
+
+Note that although calls are queued for execution but never ignored, events can still be lost if the user leaves 
+the page before all events are sent to Analytics.
 
 ## Contributing
 Contributions to the package are always welcome! 

--- a/src/limit.ts
+++ b/src/limit.ts
@@ -16,28 +16,28 @@ export function limit<C extends Callback>(callback: C, wait: number): (...args: 
     const queue: Callback[] = [];
     let timer: number|undefined;
 
-    const next = (): void => {
+    const dequeue = (): void => {
         if (timer !== undefined) {
             return;
         }
 
-        const execute = queue.shift();
+        const next = queue.shift();
 
-        if (execute !== undefined) {
-            execute();
+        if (next !== undefined) {
+            next();
 
             timer = window.setTimeout(
                 () => {
                     timer = undefined;
-                    next();
+                    dequeue();
                 },
                 wait,
             );
         }
     };
 
-    return function bound(this: any, ...args: Parameters<C>): void {
+    return function enqueue(this: any, ...args: Parameters<C>): void {
         queue.push(callback.bind(this, ...args));
-        next();
+        dequeue();
     };
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,12 +2,14 @@ import {Logger} from '@croct/plug/sdk';
 import {EventInfo, Tracker, TrackingEvent, TrackingEventType} from '@croct/plug/sdk/tracking';
 import {ObjectType, StringType, BooleanType, formatCause} from '@croct/plug/sdk/validation';
 import {Plugin} from '@croct/plug/plugin';
+import {limit} from './limit';
 
 type ListenedEvent = Extract<TrackingEventType, 'testGroupAssigned' | 'goalCompleted' | 'eventOccurred'>;
 
 export type Options = {
     variable: string,
     category: string,
+    rateLimit?: number,
     events: {[key in ListenedEvent]?: boolean},
     customEvents?: {[key: string]: boolean},
 };
@@ -47,6 +49,10 @@ export default class GoogleAnalyticsPlugin implements Plugin {
         this.tracker = tracker;
         this.logger = logger;
         this.track = this.track.bind(this);
+
+        if (options.rateLimit !== undefined && options.rateLimit > 0) {
+            this.send = limit(this.send.bind(this), options.rateLimit);
+        }
     }
 
     public enable(): void {
@@ -148,3 +154,4 @@ export default class GoogleAnalyticsPlugin implements Plugin {
         this.logger.debug(`Event "${action}" sent to Google Analytics.`);
     }
 }
+

--- a/test/limit.test.ts
+++ b/test/limit.test.ts
@@ -1,0 +1,54 @@
+import '../src/index';
+import {limit} from '../src/limit';
+
+jest.useFakeTimers();
+
+describe('A limiter function', () => {
+    test('should enqueue calls to respect specified rate limit', () => {
+        const callback = jest.fn();
+        const limitedCallback = limit(callback, 100);
+
+        limitedCallback('a', 'b');
+        limitedCallback('c', 'd');
+        limitedCallback('e', 'f');
+
+        expect(callback).toBeCalledTimes(1);
+        expect(callback).toHaveBeenLastCalledWith('a', 'b');
+
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toBeCalledTimes(2);
+        expect(callback).toHaveBeenLastCalledWith('c', 'd');
+
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toBeCalledTimes(3);
+        expect(callback).toHaveBeenLastCalledWith('e', 'f');
+
+        // No pending calls
+
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toBeCalledTimes(3);
+        expect(callback).toHaveBeenLastCalledWith('e', 'f');
+
+        // Restart
+
+        limitedCallback('g', 'h');
+        limitedCallback('i', 'j');
+
+        expect(callback).toBeCalledTimes(4);
+        expect(callback).toHaveBeenLastCalledWith('g', 'h');
+
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toBeCalledTimes(5);
+        expect(callback).toHaveBeenLastCalledWith('i', 'j');
+
+        // No pending calls again
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toBeCalledTimes(5);
+        expect(callback).toHaveBeenLastCalledWith('i', 'j');
+    });
+});

--- a/test/limit.test.ts
+++ b/test/limit.test.ts
@@ -4,7 +4,7 @@ import {limit} from '../src/limit';
 jest.useFakeTimers();
 
 describe('A limiter function', () => {
-    test('should enqueue calls to respect specified rate limit', () => {
+    test('should enqueue calls to respect the specified rate limit', () => {
         const callback = jest.fn();
         const limitedCallback = limit(callback, 100);
 
@@ -46,6 +46,7 @@ describe('A limiter function', () => {
         expect(callback).toHaveBeenLastCalledWith('i', 'j');
 
         // No pending calls again
+
         jest.advanceTimersByTime(100);
 
         expect(callback).toBeCalledTimes(5);


### PR DESCRIPTION
## Summary
All Analytics libraries implement a [rate-limiting mechanism](https://developers.google.com/analytics/devguides/collection/protocol/v1/limits-quotas) that ensures clients don't send too many hits at once, meaning that some events can be lost. The new `rateLimit` option allows limiting the maximum number of hits in a given interval. For example, passing 500ms causes the function to be called at most one time per 500ms – or two times per second.

Note that although calls are queued for execution but never ignored, events can still be lost if the user leaves 
the page before all events are sent to Analytics.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings